### PR TITLE
fix: correct MiniMax provider preset and add env var support

### DIFF
--- a/README.md
+++ b/README.md
@@ -181,9 +181,12 @@ providers:
   openrouter:
     base_url: https://openrouter.ai/api/v1
     api_key: <key>
+  minimax:
+    base_url: https://api.minimax.io/v1
+    api_key: <key>
 
-llm_provider: openrouter
-llm_model: anthropic/claude-3.5-haiku
+llm_provider: openrouter          # or: minimax
+llm_model: anthropic/claude-3.5-haiku  # MiniMax: MiniMax-M2.5 / MiniMax-M2.5-highspeed
 embedding_provider: openrouter
 embedding_model: openai/text-embedding-3-small
 

--- a/internal/config.go
+++ b/internal/config.go
@@ -99,6 +99,10 @@ func (c *Config) getProvider(name string) (*ProviderConfig, error) {
 	if envKey != "" && name == "openrouter" {
 		p.APIKey = envKey
 	}
+	mmKey := os.Getenv("MINIMAX_API_KEY")
+	if mmKey != "" && name == "minimax" {
+		p.APIKey = mmKey
+	}
 	return &p, nil
 }
 

--- a/ui/src/components/SetupPage.tsx
+++ b/ui/src/components/SetupPage.tsx
@@ -39,8 +39,8 @@ const PROVIDER_PRESETS: Record<string, { label: string; base_url: string; protoc
   },
   minimax: {
     label: "MiniMax",
-    base_url: "https://api.minimaxi.com/anthropic",
-    protocol: "anthropic",
+    base_url: "https://api.minimax.io/v1",
+    protocol: "openai",
     models: ["MiniMax-M2.5", "MiniMax-M2.5-highspeed"],
   },
   deepseek: {


### PR DESCRIPTION
## Summary

Fixes the MiniMax provider integration:

- **SetupPage.tsx**: The MiniMax preset had an incorrect API endpoint (`api.minimaxi.com/anthropic`) and wrong protocol (`anthropic`). MiniMax uses an OpenAI-compatible API at `https://api.minimax.io/v1`. Updated to use the correct URL and `openai` protocol.
- **config.go**: Added `MINIMAX_API_KEY` environment variable support, following the same pattern as the existing `OPENROUTER_API_KEY` override.
- **README.md**: Added MiniMax as a provider example in the Configuration section with model names (`MiniMax-M2.5` / `MiniMax-M2.5-highspeed`).

## Changes

| File | Change |
|------|--------|
| `ui/src/components/SetupPage.tsx` | Fix `base_url` to `https://api.minimax.io/v1`, `protocol` to `openai` |
| `internal/config.go` | Add `MINIMAX_API_KEY` env var override for `minimax` provider |
| `README.md` | Add MiniMax provider example in config docs |

## Context

MiniMax API (https://platform.minimaxi.com/) is OpenAI-compatible and should use the `openai` protocol path in `CallLLM()`. The previous configuration pointed to the old domain with Anthropic protocol, which would fail at runtime.