### PR TITLE
feat: adapt to addressing v2 — slot dependencies

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -5,7 +5,7 @@
     "": {
       "name": "clip-agent",
       "dependencies": {
-        "@pinixai/core": "^0.4.0",
+        "@pinixai/core": "git+https://github.com/epiral/pinixai-core.git#0c611670ba2c716499cc26a8ab58360a0ff0dbe2",
         "yaml": "^2.8.1",
       },
       "devDependencies": {
@@ -19,7 +19,7 @@
 
     "@modelcontextprotocol/sdk": ["@modelcontextprotocol/sdk@1.27.1", "https://registry.npmmirror.com/@modelcontextprotocol/sdk/-/sdk-1.27.1.tgz", { "dependencies": { "@hono/node-server": "^1.19.9", "ajv": "^8.17.1", "ajv-formats": "^3.0.1", "content-type": "^1.0.5", "cors": "^2.8.5", "cross-spawn": "^7.0.5", "eventsource": "^3.0.2", "eventsource-parser": "^3.0.0", "express": "^5.2.1", "express-rate-limit": "^8.2.1", "hono": "^4.11.4", "jose": "^6.1.3", "json-schema-typed": "^8.0.2", "pkce-challenge": "^5.0.0", "raw-body": "^3.0.0", "zod": "^3.25 || ^4.0", "zod-to-json-schema": "^3.25.1" }, "peerDependencies": { "@cfworker/json-schema": "^4.1.1" }, "optionalPeers": ["@cfworker/json-schema"] }, "sha512-sr6GbP+4edBwFndLbM60gf07z0FQ79gaExpnsjMGePXqFcSSb7t6iscpjk9DhFhwd+mTEQrzNafGP8/iGGFYaA=="],
 
-    "@pinixai/core": ["@pinixai/core@0.4.0", "https://registry.npmmirror.com/@pinixai/core/-/core-0.4.0.tgz", { "dependencies": { "@modelcontextprotocol/sdk": "^1.27.1", "zod": "^4.3.6" }, "peerDependencies": { "typescript": "^5.9.3" } }, "sha512-OppIvdwsTcJAyZ3eZoGUdpYFIkimhh8L/yYEW72/Ih4GZ+swDQ1H7Efmita08ycYxHeWIw1nenMIgwokI5fHkg=="],
+    "@pinixai/core": ["@pinixai/core@github:epiral/pinixai-core#0c61167", { "dependencies": { "@modelcontextprotocol/sdk": "^1.27.1", "zod": "^4.3.6" }, "peerDependencies": { "typescript": "^5.9.3" } }, "epiral-pinixai-core-0c61167", "sha512-ppzVIXDaRftGRr4V7pscWSeaBwy73ZC7DVZFW3OfUiA7l6tU1DqyPUKtOhJ2zmnlzbL19J0+Y+Wu3N0GgQpYtQ=="],
 
     "@types/bun": ["@types/bun@1.3.11", "https://registry.npmmirror.com/@types/bun/-/bun-1.3.11.tgz", { "dependencies": { "bun-types": "1.3.11" } }, "sha512-5vPne5QvtpjGpsGYXiFyycfpDF2ECyPcTSsFBMa0fraoxiQyMJ3SmuQIGhzPg2WJuWxVBoxWJ2kClYTcw/4fAg=="],
 

--- a/index.ts
+++ b/index.ts
@@ -12,7 +12,7 @@ interface PinixFileManifest {
   domain?: string;
   description?: string;
   commands?: Array<{ name?: string; description?: string }>;
-  dependencies?: Record<string, string>;
+  dependencies?: Record<string, { package: string; version: string }>;
 }
 
 const AnyOutputSchema = z.any();
@@ -25,7 +25,7 @@ type CommandDecorator = (describe?: string) => <This extends object, Value>(
 const clipCommand = command as unknown as CommandDecorator;
 
 const pinixManifest = loadPinixManifest();
-const dependencyNames = Object.keys(pinixManifest.dependencies ?? {});
+const manifestDependencies = pinixManifest.dependencies ?? {};
 
 class AgentClip extends Clip {
   private readonly runtime = new AgentClipCommands();
@@ -34,7 +34,7 @@ class AgentClip extends Clip {
   domain = pinixManifest.domain ?? "ai";
   patterns = ["send -> tool use -> memory"];
   description = pinixManifest.description ?? "AI Agent — agentic loop with memory, tools, and vision";
-  dependencies = dependencyNames;
+  dependencies = manifestDependencies;
 
   @clipCommand("发送消息并执行 agentic loop")
   send = handler(InvocationSchema, AnyOutputSchema, async (input, stream) => await this.runtime.runSend(input, stream));

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "typecheck": "/Users/cp/.bun/bin/tsc --noEmit"
   },
   "dependencies": {
-    "@pinixai/core": "^0.4.0",
+    "@pinixai/core": "git+https://github.com/epiral/pinixai-core.git#0c611670ba2c716499cc26a8ab58360a0ff0dbe2",
     "yaml": "^2.8.1"
   },
   "devDependencies": {

--- a/pinix.json
+++ b/pinix.json
@@ -50,6 +50,9 @@
     }
   ],
   "dependencies": {
-    "browser": "^1.0.0"
+    "browser": {
+      "package": "bb-browser",
+      "version": "^1.0.0"
+    }
   }
 }


### PR DESCRIPTION
## Summary
- Dependencies format updated from `Record<string,string>` to slot format `Record<string, {package, version}>`
- pinix.json: `"browser": "^1.0.0"` → `"browser": {"package": "bb-browser", "version": "^1.0.0"}`

Part of epiral/pinix#29

🤖 Generated with [Claude Code](https://claude.com/claude-code)