### PR TITLE
feat: cursor-based message pagination

### DIFF
--- a/src/commands.ts
+++ b/src/commands.ts
@@ -61,6 +61,8 @@ interface WebRun {
 interface TopicResponse {
   messages: WebMessage[];
   active_run: WebRun | null;
+  has_more: boolean;
+  oldest_id: number | null;
 }
 
 interface WebTopic {
@@ -415,9 +417,11 @@ export class AgentClipCommands {
       throw new Error("usage: get-topic <topic-id>");
     }
 
-    const limit = resolveIntegerOption(input, ["-l", "--limit"], "limit", 100);
-    const messages = loadMessagesPage(db, topicId, limit).map((message) => toWebMessage(topicId, message));
-    const activeRun = getActiveRun(db, topicId);
+    const limit = resolveIntegerOption(input, ["-l", "--limit"], "limit", 50);
+    const before = resolveIntegerOption(input, ["--before"], "before", 0) || undefined;
+    const page = loadMessagesPage(db, topicId, limit, before);
+    const messages = page.messages.map((message) => toWebMessage(topicId, message));
+    const activeRun = before ? null : getActiveRun(db, topicId);
 
     return {
       messages,
@@ -430,6 +434,8 @@ export class AgentClipCommands {
             output: activeRun.async ? readRunOutput(activeRun.id) : undefined,
           }
         : null,
+      has_more: page.has_more,
+      oldest_id: page.oldest_id,
     };
   }
 

--- a/src/db.ts
+++ b/src/db.ts
@@ -227,34 +227,55 @@ function toMessage(row: {
   };
 }
 
-export function loadMessagesPage(db: Database, topicId: string, limit = 0): Message[] {
-  if (limit > 0) {
-    const rows = db.query<{
-      role: string;
-      content: string | null;
-      tool_calls: string | null;
-      tool_call_id: string | null;
-      reasoning: string | null;
-      usage: string | null;
-    }, [string, number]>(
-      `SELECT role, content, tool_calls, tool_call_id, reasoning, usage FROM (
-        SELECT role, content, tool_calls, tool_call_id, reasoning, usage, id
-        FROM messages WHERE topic_id = ? ORDER BY id DESC LIMIT ?
-      ) sub ORDER BY id ASC`,
-    ).all(topicId, limit);
-    return rows.map(toMessage);
-  }
+export interface MessagePage {
+  messages: Message[];
+  oldest_id: number | null;
+  has_more: boolean;
+}
 
-  return db.query<{
+export function loadMessagesPage(db: Database, topicId: string, limit = 0, before?: number): MessagePage {
+  type Row = {
+    id: number;
     role: string;
     content: string | null;
     tool_calls: string | null;
     tool_call_id: string | null;
     reasoning: string | null;
     usage: string | null;
-  }, [string]>(
-    "SELECT role, content, tool_calls, tool_call_id, reasoning, usage FROM messages WHERE topic_id = ? ORDER BY id ASC",
-  ).all(topicId).map(toMessage);
+  };
+
+  let rows: Row[];
+
+  if (limit > 0 && before) {
+    rows = db.query<Row, [string, number, number]>(
+      `SELECT id, role, content, tool_calls, tool_call_id, reasoning, usage FROM (
+        SELECT id, role, content, tool_calls, tool_call_id, reasoning, usage
+        FROM messages WHERE topic_id = ? AND id < ? ORDER BY id DESC LIMIT ?
+      ) sub ORDER BY id ASC`,
+    ).all(topicId, before, limit);
+  } else if (limit > 0) {
+    rows = db.query<Row, [string, number]>(
+      `SELECT id, role, content, tool_calls, tool_call_id, reasoning, usage FROM (
+        SELECT id, role, content, tool_calls, tool_call_id, reasoning, usage
+        FROM messages WHERE topic_id = ? ORDER BY id DESC LIMIT ?
+      ) sub ORDER BY id ASC`,
+    ).all(topicId, limit);
+  } else {
+    rows = db.query<Row, [string]>(
+      "SELECT id, role, content, tool_calls, tool_call_id, reasoning, usage FROM messages WHERE topic_id = ? ORDER BY id ASC",
+    ).all(topicId);
+  }
+
+  const oldestId = rows.length > 0 ? rows[0].id : null;
+  const hasMore = oldestId !== null && !!db.query<{ c: number }, [string, number]>(
+    "SELECT 1 as c FROM messages WHERE topic_id = ? AND id < ? LIMIT 1",
+  ).get(topicId, oldestId);
+
+  return {
+    messages: rows.map(toMessage),
+    oldest_id: oldestId,
+    has_more: hasMore,
+  };
 }
 
 export function loadMessagesByRunID(db: Database, runId: string): Message[] {

--- a/ui/src/components/ChatLayout.tsx
+++ b/ui/src/components/ChatLayout.tsx
@@ -173,12 +173,15 @@ export function ChatLayout() {
 
         {/* Messages */}
         <div className="flex-1 overflow-hidden relative">
-          <MessageList 
-            ref={messageListRef} 
-            messages={chat.messages} 
-            isStreaming={chat.isStreaming} 
-            onSendPrompt={chat.send} 
-            agentName={agentName} 
+          <MessageList
+            ref={messageListRef}
+            messages={chat.messages}
+            isStreaming={chat.isStreaming}
+            onSendPrompt={chat.send}
+            agentName={agentName}
+            hasMore={chat.hasMore}
+            isLoadingMore={chat.isLoadingMore}
+            onLoadMore={chat.loadMore}
           />
         </div>
 

--- a/ui/src/components/MessageList.tsx
+++ b/ui/src/components/MessageList.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useRef, useState, useImperativeHandle, forwardRef } from "react";
+import { useEffect, useLayoutEffect, useRef, useState, useImperativeHandle, forwardRef } from "react";
 import type { ChatMessage } from "../lib/types";
 import { MessageBubble } from "./MessageBubble";
 import { Globe, Sparkles, Search, Package, ChevronDown } from "lucide-react";
@@ -10,6 +10,9 @@ interface MessageListProps {
   onSendPrompt?: (msg: string) => void;
   agentName?: string;
   onScrollButtonChange?: (show: boolean) => void;
+  hasMore?: boolean;
+  isLoadingMore?: boolean;
+  onLoadMore?: () => void;
 }
 
 export interface MessageListHandle {
@@ -17,7 +20,7 @@ export interface MessageListHandle {
   showScrollButton: boolean;
 }
 
-export const MessageList = forwardRef<MessageListHandle, MessageListProps>(function MessageList({ messages, isStreaming, onSendPrompt, agentName, onScrollButtonChange }, ref) {
+export const MessageList = forwardRef<MessageListHandle, MessageListProps>(function MessageList({ messages, isStreaming, onSendPrompt, agentName, onScrollButtonChange, hasMore, isLoadingMore, onLoadMore }, ref) {
   const scrollRef = useRef<HTMLDivElement>(null);
   const [showScrollButton, setShowScrollButton] = useState(false);
   const [userHasScrolledUp, setUserHasScrolledUp] = useState(false);
@@ -44,7 +47,7 @@ export const MessageList = forwardRef<MessageListHandle, MessageListProps>(funct
   const handleScroll = (e: React.UIEvent<HTMLDivElement>) => {
     const { scrollTop, scrollHeight, clientHeight } = e.currentTarget;
     const distanceToBottom = scrollHeight - scrollTop - clientHeight;
-    
+
     // If user scrolled up more than 100px from bottom
     if (distanceToBottom > 100) {
       setUserHasScrolledUp(true);
@@ -54,6 +57,11 @@ export const MessageList = forwardRef<MessageListHandle, MessageListProps>(funct
       setUserHasScrolledUp(false);
       setShowScrollButton(false);
       onScrollButtonChange?.(false);
+    }
+
+    // Load more when scrolled near top
+    if (scrollTop < 100 && hasMore && !isLoadingMore && onLoadMore) {
+      onLoadMore();
     }
   };
 
@@ -72,6 +80,26 @@ export const MessageList = forwardRef<MessageListHandle, MessageListProps>(funct
       return () => clearTimeout(timeout);
     }
   }, [messages, isStreaming, userHasScrolledUp]);
+
+  // Preserve scroll position when prepending older messages
+  const prevScrollHeightRef = useRef(0);
+
+  // Capture scrollHeight before DOM update when loading more
+  useEffect(() => {
+    if (isLoadingMore && scrollRef.current) {
+      prevScrollHeightRef.current = scrollRef.current.scrollHeight;
+    }
+  }, [isLoadingMore]);
+
+  // After prepend render: restore scroll position
+  useLayoutEffect(() => {
+    const el = scrollRef.current;
+    const prevHeight = prevScrollHeightRef.current;
+    if (el && prevHeight > 0 && el.scrollHeight > prevHeight) {
+      el.scrollTop = el.scrollHeight - prevHeight;
+      prevScrollHeightRef.current = 0;
+    }
+  }, [messages]);
 
   // Initial scroll on load
   useEffect(() => {
@@ -134,6 +162,21 @@ export const MessageList = forwardRef<MessageListHandle, MessageListProps>(funct
         className="h-full overflow-y-auto w-full scroll-smooth no-scrollbar"
       >
         <div className="pb-32">
+          {isLoadingMore && (
+            <div className="flex justify-center py-4">
+              <span className="text-xs text-muted-foreground animate-pulse">Loading...</span>
+            </div>
+          )}
+          {hasMore && !isLoadingMore && (
+            <div className="flex justify-center py-3">
+              <button
+                onClick={onLoadMore}
+                className="text-xs text-muted-foreground hover:text-foreground transition-colors"
+              >
+                {t("Load earlier messages")}
+              </button>
+            </div>
+          )}
           {messages.map((msg) => (
             <MessageBubble key={msg.id} message={msg} agentName={agentName} />
           ))}

--- a/ui/src/lib/agent.ts
+++ b/ui/src/lib/agent.ts
@@ -29,10 +29,14 @@ export interface TopicResponse {
     async: boolean;
     output?: string;
   } | null;
+  has_more: boolean;
+  oldest_id: number | null;
 }
 
-export async function getTopicData(topicId: string): Promise<TopicResponse> {
-  return invoke<TopicResponse>("get-topic", { args: [topicId] });
+export async function getTopicData(topicId: string, before?: number): Promise<TopicResponse> {
+  const args = [topicId];
+  if (before) args.push("--before", String(before));
+  return invoke<TopicResponse>("get-topic", { args });
 }
 
 export async function deleteTopic(topicId: string): Promise<void> {

--- a/ui/src/lib/useChat.ts
+++ b/ui/src/lib/useChat.ts
@@ -109,11 +109,17 @@ export function useChat() {
   const [isStreaming, setIsStreaming] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const [activeRunId, setActiveRunId] = useState<string | null>(null);
+  const [hasMore, setHasMore] = useState(false);
+  const [isLoadingMore, setIsLoadingMore] = useState(false);
 
   // Per-topic message cache (preserves streaming state across switches)
   const messageCacheRef = useRef<Map<string, ChatMessage[]>>(new Map());
   // Active stream state (survives topic switches)
   const streamRef = useRef<StreamState | null>(null);
+  // Pagination cursor: oldest message ID in current loaded set
+  const oldestIdRef = useRef<number | null>(null);
+  // Raw history for prepending older pages
+  const historyRef = useRef<HistoryMessage[]>([]);
 
   const loadTopics = useCallback(async () => {
     try {
@@ -134,10 +140,13 @@ export function useChat() {
     setCurrentTopicId(topicId);
     setError(null);
     setActiveRunId(null);
+    setHasMore(false);
 
     if (!topicId) {
       setMessages([]);
       setIsStreaming(false);
+      historyRef.current = [];
+      oldestIdRef.current = null;
       return;
     }
 
@@ -156,6 +165,9 @@ export function useChat() {
     // Load from backend
     try {
       const data = await agent.getTopicData(topicId);
+      historyRef.current = data.messages;
+      oldestIdRef.current = data.oldest_id;
+      setHasMore(data.has_more);
       const chatMsgs = historyToChatMessages(data.messages);
 
       // If there's an active run, show indicator
@@ -191,6 +203,29 @@ export function useChat() {
     }
   // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [currentTopicId, messages]);
+
+  // ─── Load more (older messages) ───
+  const loadMore = useCallback(async () => {
+    if (!currentTopicId || !oldestIdRef.current || isLoadingMore || !hasMore) return;
+    setIsLoadingMore(true);
+    try {
+      const data = await agent.getTopicData(currentTopicId, oldestIdRef.current);
+      if (data.messages.length === 0) {
+        setHasMore(false);
+        return;
+      }
+      historyRef.current = [...data.messages, ...historyRef.current];
+      oldestIdRef.current = data.oldest_id;
+      setHasMore(data.has_more);
+      const chatMsgs = historyToChatMessages(historyRef.current);
+      setMessages(chatMsgs);
+      messageCacheRef.current.set(currentTopicId, chatMsgs);
+    } catch (e) {
+      setError(e instanceof Error ? e.message : String(e));
+    } finally {
+      setIsLoadingMore(false);
+    }
+  }, [currentTopicId, isLoadingMore, hasMore]);
 
   // ─── Send message ───
   const send = useCallback((message: string, topicId?: string, files?: File[]) => {
@@ -399,10 +434,13 @@ export function useChat() {
     isStreaming,
     error,
     activeRunId,
+    hasMore,
+    isLoadingMore,
     loadTopics,
     selectTopic,
     send,
     cancel,
     removeTopic,
+    loadMore,
   };
 }


### PR DESCRIPTION
## Summary

- Load newest 50 messages on topic open (down from 100)
- Scroll to top or click button to load older pages
- Scroll position preserved when prepending older messages

## Changes

| File | Change |
|---|---|
| `src/db.ts` | `loadMessagesPage` supports `before` cursor, returns `{ messages, oldest_id, has_more }` |
| `src/commands.ts` | `get-topic` accepts `--before`, returns `has_more` + `oldest_id`, default limit 50 |
| `ui/.../agent.ts` | `getTopicData(topicId, before?)`, `TopicResponse` adds pagination fields |
| `ui/.../useChat.ts` | `loadMore()`, `hasMore`, `isLoadingMore` state + `historyRef` for prepending |
| `ui/.../MessageList.tsx` | Scroll-to-top detection, loading indicator, "Load earlier messages" button |
| `ui/.../ChatLayout.tsx` | Pass pagination props to MessageList |

## Test plan

- [ ] Open a topic with 100+ messages — only 50 loaded initially
- [ ] Scroll to top — older messages load, scroll position stable
- [ ] Click "Load earlier messages" button — works same as scroll
- [ ] Small topic (<50 messages) — no "load more" shown
- [ ] Streaming still works correctly after pagination

🤖 Generated with [Claude Code](https://claude.com/claude-code)