### PR TITLE
fix(sw): network-first for non-hashed assets

### DIFF
--- a/clip.json
+++ b/clip.json
@@ -1,6 +1,6 @@
 {
   "name": "@pinix/agent",
-  "version": "0.7.13",
+  "version": "0.7.14",
   "description": "AI Agent — agentic loop with shell, packages, and memory",
   "runtime": "bun",
   "main": "index.ts",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pinix/agent",
-  "version": "0.7.13",
+  "version": "0.7.14",
   "description": "AI Agent — agentic loop with shell, packages, and memory",
   "type": "module",
   "scripts": {

--- a/ui/public/sw.js
+++ b/ui/public/sw.js
@@ -13,20 +13,33 @@ self.addEventListener('activate', (e) => {
 self.addEventListener('fetch', (e) => {
   const url = new URL(e.request.url);
 
-  // Only cache same-origin GET requests for static assets
   if (e.request.method !== 'GET' || url.origin !== self.location.origin) return;
   if (!STATIC_EXTENSIONS.some((ext) => url.pathname.endsWith(ext))) return;
 
-  e.respondWith(
-    caches.match(e.request).then((cached) => {
-      if (cached) return cached;
-      return fetch(e.request).then((response) => {
+  if (url.pathname.startsWith('/assets/')) {
+    // Hashed assets: cache-first (hash in filename = immutable)
+    e.respondWith(
+      caches.match(e.request).then((cached) => {
+        if (cached) return cached;
+        return fetch(e.request).then((response) => {
+          if (response.ok) {
+            const clone = response.clone();
+            caches.open(CACHE_NAME).then((cache) => cache.put(e.request, clone));
+          }
+          return response;
+        });
+      })
+    );
+  } else {
+    // Non-hashed static files: network-first, cache fallback
+    e.respondWith(
+      fetch(e.request).then((response) => {
         if (response.ok) {
           const clone = response.clone();
           caches.open(CACHE_NAME).then((cache) => cache.put(e.request, clone));
         }
         return response;
-      });
-    })
-  );
+      }).catch(() => caches.match(e.request))
+    );
+  }
 });

--- a/web/sw.js
+++ b/web/sw.js
@@ -13,20 +13,33 @@ self.addEventListener('activate', (e) => {
 self.addEventListener('fetch', (e) => {
   const url = new URL(e.request.url);
 
-  // Only cache same-origin GET requests for static assets
   if (e.request.method !== 'GET' || url.origin !== self.location.origin) return;
   if (!STATIC_EXTENSIONS.some((ext) => url.pathname.endsWith(ext))) return;
 
-  e.respondWith(
-    caches.match(e.request).then((cached) => {
-      if (cached) return cached;
-      return fetch(e.request).then((response) => {
+  if (url.pathname.startsWith('/assets/')) {
+    // Hashed assets: cache-first (hash in filename = immutable)
+    e.respondWith(
+      caches.match(e.request).then((cached) => {
+        if (cached) return cached;
+        return fetch(e.request).then((response) => {
+          if (response.ok) {
+            const clone = response.clone();
+            caches.open(CACHE_NAME).then((cache) => cache.put(e.request, clone));
+          }
+          return response;
+        });
+      })
+    );
+  } else {
+    // Non-hashed static files: network-first, cache fallback
+    e.respondWith(
+      fetch(e.request).then((response) => {
         if (response.ok) {
           const clone = response.clone();
           caches.open(CACHE_NAME).then((cache) => cache.put(e.request, clone));
         }
         return response;
-      });
-    })
-  );
+      }).catch(() => caches.match(e.request))
+    );
+  }
 });


### PR DESCRIPTION
## Summary
- `assets/*` (hashed filenames): keep cache-first — hash changes = new URL
- Other static files (icon.svg etc): network-first with cache fallback — always get latest, graceful offline

## Test plan
- [x] Deployed to Mac Mini + parall-local via registry publish (0.7.14)

🤖 Generated with [Claude Code](https://claude.com/claude-code)