### PR TITLE
fix: preserve large integer strings in parseScalar

### DIFF
--- a/src/tools.ts
+++ b/src/tools.ts
@@ -913,7 +913,10 @@ function parseScalar(value: string): unknown {
 
   const asNumber = Number(value);
   if (Number.isFinite(asNumber) && value.trim() !== '') {
-    return asNumber;
+    if (!Number.isInteger(asNumber) || Number.isSafeInteger(asNumber)) {
+      return asNumber;
+    }
+    return value;
   }
 
   // Try JSON object or array


### PR DESCRIPTION
## Summary
- `parseScalar` converts all numeric strings to `Number`, but tweet IDs / Snowflake IDs exceed `Number.MAX_SAFE_INTEGER` (2^53-1), causing silent precision loss (e.g. `2055079539374747769` → `2055079539374747600`, off by 169)
- Agent-clip on Mac Mini fails to invoke `twitter thread` because the mangled ID doesn't match any tweet
- Fix: keep integer strings as `string` when they exceed the safe integer range; floats and normal integers are unaffected

## Test plan
- [x] Reproduced: `Number("2055079539374747769")` → `2055079539374747600`
- [x] Verified fix: tweet ID stays `"2055079539374747769"` (string), normal ints/floats still convert to number
- [ ] Mac Mini: merge → update agent-clip → `twitter thread --tweet_id 2055079539374747769` via agent